### PR TITLE
Change placeholder to show autofix

### DIFF
--- a/client/src/pages/Auth/Register.js
+++ b/client/src/pages/Auth/Register.js
@@ -161,7 +161,7 @@ const Register = () => {
               onChange={(e) => setDOB(e.target.value)}
               className="form-control"
               id="exampleInputDOB1"
-              placeholder="Enter Your DOB"
+              placeholder="Date of Birth"
               required
             />
           </div>


### PR DESCRIPTION
This pull request makes a minor update to the user registration form to improve clarity for users. The placeholder text in the date of birth input field has been changed from "Enter Your DOB" to "Date of Birth".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Date of Birth input field placeholder text on the registration form for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->