### PR TITLE
Change placeholder to show autofix

### DIFF
--- a/client/src/pages/Auth/Register.js
+++ b/client/src/pages/Auth/Register.js
@@ -161,7 +161,7 @@ const Register = () => {
               onChange={(e) => setDOB(e.target.value)}
               className="form-control"
               id="exampleInputDOB1"
-              placeholder="Enter Your DOB"
+              placeholder="Date of Birth"
               required
             />
           </div>


### PR DESCRIPTION
This pull request makes a small improvement to the placeholder text for the date of birth field in the registration form, making it clearer for users.

* Changed the placeholder in the date of birth input field from "Enter Your DOB" to "Date of Birth" for improved clarity in `Register.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated date of birth input field placeholder text for improved clarity and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->