### PR TITLE
Change placeholder to show autofix

### DIFF
--- a/client/src/pages/Auth/Register.js
+++ b/client/src/pages/Auth/Register.js
@@ -161,7 +161,7 @@ const Register = () => {
               onChange={(e) => setDOB(e.target.value)}
               className="form-control"
               id="exampleInputDOB1"
-              placeholder="Enter Your DOB"
+              placeholder="Date of Birth"
               required
             />
           </div>


### PR DESCRIPTION
This pull request makes a minor update to the user interface in the registration form by changing the placeholder text for the date of birth input field to be clearer and more user-friendly.

* Changed the `placeholder` text for the date of birth field from "Enter Your DOB" to "Date of Birth" in `Register.js` for improved clarity.