### PR TITLE
Change placeholder to show autofix

### DIFF
--- a/client/src/pages/Auth/Register.js
+++ b/client/src/pages/Auth/Register.js
@@ -161,7 +161,7 @@ const Register = () => {
               onChange={(e) => setDOB(e.target.value)}
               className="form-control"
               id="exampleInputDOB1"
-              placeholder="Enter Your DOB"
+              placeholder="Date of Birth"
               required
             />
           </div>


### PR DESCRIPTION
This pull request makes a small improvement to the user interface on the registration page by updating the placeholder text for the date of birth input field to be clearer and more user-friendly.

* Changed the placeholder text for the date of birth field in `Register.js` from "Enter Your DOB" to "Date of Birth" for better clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text in the Date of Birth field on the registration page for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->