### PR TITLE
Change placeholder to show autofix

### DIFF
--- a/client/src/pages/Auth/Register.js
+++ b/client/src/pages/Auth/Register.js
@@ -161,7 +161,7 @@ const Register = () => {
               onChange={(e) => setDOB(e.target.value)}
               className="form-control"
               id="exampleInputDOB1"
-              placeholder="Enter Your DOB"
+              placeholder="Date of Birth"
               required
             />
           </div>


### PR DESCRIPTION
This pull request makes a small change to the `Register` component to improve the user interface by updating the placeholder text for the date of birth input field.

* Changed the placeholder text in the date of birth input field from "Enter Your DOB" to "Date of Birth" in `client/src/pages/Auth/Register.js` for improved clarity.